### PR TITLE
Reduce CTA clutter and clarify contact form

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
-import { MapPin, Phone, Mail, Clock, Send, MessageCircle, Bot } from 'lucide-react';
+import { MapPin, Phone, Mail, Clock, Send, MessageCircle, Bot, Lock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 
@@ -160,7 +160,7 @@ const Contact = () => {
               <form onSubmit={handleSubmit} className="space-y-5">
                 <div>
                   <label htmlFor="name" className="block text-sm font-medium text-slate-700 mb-1.5">
-                    {t('contact.name_label')}
+                    {t('contact.name_label')} <span className="text-red-500" aria-hidden="true">*</span>
                   </label>
                   <input
                     type="text" id="name" name="name" value={formData.name} onChange={handleChange} required
@@ -175,7 +175,7 @@ const Contact = () => {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
                   <div>
                     <label htmlFor="email" className="block text-sm font-medium text-slate-700 mb-1.5">
-                      {t('contact.email_label')}
+                      {t('contact.email_label')} <span className="text-red-500" aria-hidden="true">*</span>
                     </label>
                     <input
                       type="email" id="email" name="email" value={formData.email} onChange={handleChange} required
@@ -189,7 +189,7 @@ const Contact = () => {
                   
                   <div>
                     <label htmlFor="phone" className="block text-sm font-medium text-slate-700 mb-1.5">
-                      {t('contact.phone_label')}
+                      {t('contact.phone_label')} <span className="text-red-500" aria-hidden="true">*</span>
                     </label>
                     <input
                       type="tel" id="phone" name="phone" value={formData.phone} onChange={handleChange} required
@@ -204,7 +204,7 @@ const Contact = () => {
                 
                 <div>
                   <label htmlFor="message" className="block text-sm font-medium text-slate-700 mb-1.5">
-                    {t('contact.message_label')}
+                    {t('contact.message_label')} <span className="text-red-500" aria-hidden="true">*</span>
                   </label>
                   <textarea
                     id="message" name="message" value={formData.message} onChange={handleChange} required rows="4"
@@ -217,7 +217,7 @@ const Contact = () => {
                 </div>
 
                 <div className="pt-2">
-                  <label className="inline-flex items-start gap-2 text-xs text-slate-600 cursor-pointer">
+                  <label className="inline-flex items-start gap-2 text-xs text-blue-800 bg-blue-50 border border-blue-200 p-3 rounded-md cursor-pointer">
                     <input
                       type="checkbox"
                       name="consent"
@@ -228,6 +228,7 @@ const Contact = () => {
                       className="mt-0.5 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
                       required
                     />
+                    <Lock size={14} className="mt-0.5 text-blue-600" />
                     <span dangerouslySetInnerHTML={{ __html: t('privacy.form_consent_html') }} />
                   </label>
                   {errors.consent && <p id="error-consent" className="mt-1 text-xs text-red-600">{errors.consent}</p>}

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -122,17 +122,7 @@ const Services = () => {
           ))}
         </motion.div>
 
-        <motion.div 
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.5, delay: 0.4 }}
-          className="mt-16 text-center"
-        >
-          <Button size="lg" variant="cta" onClick={handleAgendarClick}>
-            {t('services.schedule_button')}
-          </Button>
-        </motion.div>
+        {/* Consolidated CTA moved to Navbar/FloatingCTA to reduce repetition */}
       </div>
     </section>
   );

--- a/src/components/Testimonials.jsx
+++ b/src/components/Testimonials.jsx
@@ -137,17 +137,17 @@ const Testimonials = ({ limit }) => {
                   variant="ghost"
                   size="icon"
                   onClick={prevSlide}
-                  className="absolute left-4 top-1/2 transform -translate-y-1/2 bg-white/80 hover:bg-white shadow-md"
+                  className="absolute left-4 top-1/2 transform -translate-y-1/2 bg-blue-600 text-white hover:bg-blue-700 shadow-md"
                   aria-label={t('testimonials.previous')}
                 >
                   <ChevronLeft size={20} />
                 </Button>
-                
+
                 <Button
                   variant="ghost"
                   size="icon"
                   onClick={nextSlide}
-                  className="absolute right-4 top-1/2 transform -translate-y-1/2 bg-white/80 hover:bg-white shadow-md"
+                  className="absolute right-4 top-1/2 transform -translate-y-1/2 bg-blue-600 text-white hover:bg-blue-700 shadow-md"
                   aria-label={t('testimonials.next')}
                 >
                   <ChevronRight size={20} />


### PR DESCRIPTION
## Summary
- Remove extra scheduling button from Services section
- Improve testimonial carousel navigation visibility
- Mark required contact fields and highlight LGPD consent with lock icon

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5c7f30e9c8328b9afdf39d498b513