### PR TITLE
feat(faq): add preview section and page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ const TestimonialsPage = lazy(() => import('@/pages/TestimonialsPage'));
 const PrivacyPolicyPage = lazy(() => import('@/pages/PrivacyPolicyPage'));
 const ServiceDetailPage = lazy(() => import('@/pages/ServiceDetailPage'));
 const LensesPage = lazy(() => import('@/pages/LensesPage'));
+const FAQPage = lazy(() => import('@/pages/FAQPage'));
 // EpisodePage removido junto com PodcastPage
 import ScrollToTop from '@/components/ScrollToTop';
 import { Toaster } from '@/components/ui/toaster';
@@ -37,6 +38,7 @@ function App() {
           <Route path="/contato" element={<ContactPage />} />
           <Route path="/lentes" element={<LensesPage />} />
           {/* Rotas de podcast removidas - redirecionamento será feito no componente */}
+          <Route path="/faq" element={<FAQPage />} />
           <Route path="/privacy" element={<PrivacyPolicyPage />} />
         </Routes>
       </Suspense>

--- a/src/components/FAQPreview.jsx
+++ b/src/components/FAQPreview.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { HelpCircle } from 'lucide-react';
+
+const FAQPreview = () => {
+  const { t } = useTranslation();
+
+  const faqs = [
+    t('faq.questions.lenses_cost', { returnObjects: true }),
+    t('faq.questions.pediatric_age', { returnObjects: true }),
+    t('faq.questions.medical_report', { returnObjects: true }),
+    t('faq.questions.glaucoma_treatment', { returnObjects: true }),
+    t('faq.questions.insurance', { returnObjects: true })
+  ];
+
+  return (
+    <section className="py-16 bg-gradient-to-br from-slate-50/30 to-blue-50/30">
+      <div className="container mx-auto px-4 md:px-6">
+        <div className="text-center mb-12">
+          <div className="inline-flex items-center px-4 py-2 rounded-full bg-blue-100 text-blue-700 text-sm font-medium mb-4">
+            <HelpCircle size={16} className="mr-2" />
+            {t('faqPreview.badge')}
+          </div>
+          <h2 className="text-3xl md:text-4xl font-bold">
+            {t('faqPreview.title')}
+          </h2>
+        </div>
+
+        <div className="flex overflow-x-auto gap-6 pb-4 snap-x snap-mandatory" aria-label={t('faqPreview.title')}>
+          {faqs.map((faq, idx) => (
+            <div
+              key={idx}
+              className="w-80 flex-shrink-0 p-6 rounded-2xl bg-white/30 backdrop-blur-lg border border-white/20 shadow-lg transition-transform duration-300 hover:-translate-y-2 hover:shadow-2xl hover:rotate-1 snap-center"
+            >
+              <h3 className="font-semibold text-lg mb-2">{faq.question}</h3>
+              <p className="text-slate-700 text-sm">{faq.answer}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="text-center mt-10">
+          <Link to="/faq" className="text-blue-600 font-medium hover:underline">
+            {t('faqPreview.link')}
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default FAQPreview;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -307,6 +307,11 @@
     "description": "Learn more about {{serviceTitleLowercase}} at Saraiva Vision. We offer advanced treatments and diagnoses for your eye health.",
     "keywords": "{{serviceTitleLowercase}}, ophthalmology, eye health, eye clinic"
   },
+  "faqPreview": {
+    "badge": "Quick Answers",
+    "title": "Frequently Asked Questions",
+    "link": "See all questions"
+  },
   "faq": {
     "badge": "Frequently Asked Questions",
     "title": "Frequently Asked Questions",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -64,6 +64,11 @@
       "years": "Anos de Experiência"
     }
   },
+  "faqPreview": {
+    "badge": "Perguntas rápidas",
+    "title": "Dúvidas frequentes",
+    "link": "Ver todas as perguntas"
+  },
   "faq": {
     "badge": "Dúvidas Frequentes",
     "title": "Perguntas Frequentes",
@@ -493,6 +498,11 @@
     "title": "{{serviceTitle}} | Clínica Saraiva Vision",
     "description": "Saiba mais sobre {{serviceTitleLowercase}} na Saraiva Vision. Oferecemos tratamentos e diagnósticos avançados para sua saúde ocular.",
     "keywords": "{{serviceTitleLowercase}}, oftalmologia, saúde ocular, clínica de olhos"
+  },
+  "faqMeta": {
+    "title": "FAQ | Clínica Saraiva Vision",
+    "description": "Respostas para dúvidas comuns sobre consultas, exames, cirurgias e lentes de contato.",
+    "keywords": "faq oftalmologia, perguntas exame de vista, clinica de olhos faq, perguntas lentes de contato"
   },
   "lensesMeta": {
     "title": "👁️ Lentes de Contato Caratinga | Adaptação Profissional | Saraiva Vision",

--- a/src/pages/FAQPage.jsx
+++ b/src/pages/FAQPage.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Navbar from '@/components/Navbar';
+import Footer from '@/components/Footer';
+import SEOHead from '@/components/SEOHead';
+import FAQ from '@/components/FAQ';
+import { useTranslation } from 'react-i18next';
+
+const FAQPage = () => {
+  const { t } = useTranslation();
+  const seo = {
+    title: t('faqMeta.title'),
+    description: t('faqMeta.description'),
+    keywords: t('faqMeta.keywords'),
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-white">
+      <SEOHead {...seo} />
+      <Navbar />
+      <main className="flex-1 pt-28">
+        <FAQ />
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default FAQPage;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -6,11 +6,10 @@ import { useHomeSEO } from '@/hooks/useSEO';
 import Navbar from '@/components/Navbar';
 import Hero from '@/components/Hero';
 import Services from '@/components/Services';
-import ContactLenses from '@/components/ContactLenses';
 import About from '@/components/About';
 import Testimonials from '@/components/Testimonials';
 import BlogSection from '@/components/BlogSection';
-import FAQ from '@/components/FAQ';
+import FAQPreview from '@/components/FAQPreview';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
 import GoogleLocalSection from '@/components/GoogleLocalSection';
@@ -56,7 +55,7 @@ function HomePage() {
             <a href="/lentes" className="text-blue-600 font-medium hover:underline text-lg">Ver detalhes</a>
           </div>
         </section>
-        <FAQ />
+        <FAQPreview />
         <Contact />
         <GoogleLocalSection />
         <BlogSection />


### PR DESCRIPTION
## Summary
- add horizontally scrolling FAQ preview with glass/3D cards
- create dedicated FAQ page and route
- wire preview and translate strings

## Testing
- `npx eslint -c /tmp/eslintrc.cjs src` *(fails: cannot find config "@vitejs/eslint-config-react")*
- `npm test` *(fails: multiple tests fail, e.g., Services component)*

------
https://chatgpt.com/codex/tasks/task_e_68ade1e70e68832891445810532cc3fd