### PR TITLE
Add local SEO blog section with sample posts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,8 @@ const PrivacyPolicyPage = lazy(() => import('@/pages/PrivacyPolicyPage'));
 const ServiceDetailPage = lazy(() => import('@/pages/ServiceDetailPage'));
 const LensesPage = lazy(() => import('@/pages/LensesPage'));
 const FAQPage = lazy(() => import('@/pages/FAQPage'));
+const BlogPage = lazy(() => import('@/pages/BlogPage'));
+const PostPage = lazy(() => import('@/pages/PostPage'));
 // EpisodePage removido junto com PodcastPage
 import ScrollToTop from '@/components/ScrollToTop';
 import { Toaster } from '@/components/ui/toaster';
@@ -18,8 +20,9 @@ import ConsentManager from '@/components/ConsentManager';
 import FloatingCTA from '@/components/FloatingCTA';
 // import ExitPopupTester from '@/components/ExitPopupTester';
 
-function App() {
+  function App() {
   const { i18n } = useTranslation();
+  const wordpressUrl = import.meta.env.VITE_WORDPRESS_URL;
 
   useEffect(() => {
     document.documentElement.lang = i18n.language;
@@ -40,8 +43,10 @@ function App() {
           {/* Rotas de podcast removidas - redirecionamento será feito no componente */}
           <Route path="/faq" element={<FAQPage />} />
           <Route path="/privacy" element={<PrivacyPolicyPage />} />
+          <Route path="/blog" element={<BlogPage wordpressUrl={wordpressUrl} />} />
+          <Route path="/blog/:slug" element={<PostPage wordpressUrl={wordpressUrl} />} />
         </Routes>
-      </Suspense>
+        </Suspense>
       <Toaster />
       <ConsentManager />
       <FloatingCTA />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -34,6 +34,7 @@ const Navbar = () => {
     { name: t('navbar.lenses'), href: '/lentes', internal: true, isRoute: true },
     { name: t('navbar.about'), href: '/sobre', internal: true, isRoute: true },
     { name: t('navbar.testimonials'), href: '/depoimentos', internal: true, isRoute: true },
+    { name: t('navbar.blog'), href: '/blog', internal: true, isRoute: true },
     { name: t('navbar.contact'), href: '/contato', internal: true, isRoute: true },
     { name: 'Instagram', href: 'https://www.instagram.com/saraiva_vision/', internal: false },
   ], [t]);

--- a/src/lib/blogPosts.js
+++ b/src/lib/blogPosts.js
@@ -1,0 +1,44 @@
+import { clinicInfo } from './clinicInfo';
+
+const blogPosts = [
+  {
+    id: 1,
+    slug: 'exame-de-visao-em-caratinga',
+    date: '2024-06-01',
+    image: 'https://placehold.co/600x400?text=Caratinga',
+    author: 'Dr. Philipe Saraiva',
+    translations: {
+      pt: {
+        title: 'Exame de Visão em Caratinga: Onde Fazer e Quando Agendar',
+        excerpt: 'Descubra onde realizar exame de vista em Caratinga e quando é o momento ideal para agendar sua consulta.',
+        content: `<p>Manter a saúde ocular em dia é essencial para quem vive em Caratinga. Na <strong>${clinicInfo.name}</strong>, utilizamos equipamentos modernos para garantir diagnósticos precisos. Agende seu exame de vista e cuide melhor dos seus olhos.</p>`
+      },
+      en: {
+        title: 'Eye Exam in Caratinga: Where to Go and When to Schedule',
+        excerpt: 'Find out where to get an eye exam in Caratinga and the best time to schedule your appointment.',
+        content: `<p>Keeping your eyes healthy is essential, especially in Caratinga. At <strong>${clinicInfo.name}</strong>, we use modern equipment to ensure precise diagnoses. Book your eye exam and take better care of your vision.</p>`
+      }
+    }
+  },
+  {
+    id: 2,
+    slug: 'lentes-de-contato-caratinga',
+    date: '2024-06-10',
+    image: 'https://placehold.co/600x400?text=Lentes',
+    author: 'Equipe Saraiva Vision',
+    translations: {
+      pt: {
+        title: 'Lentes de Contato em Caratinga: Guia Completo para Iniciantes',
+        excerpt: 'Veja como escolher e cuidar das lentes de contato em Caratinga com dicas dos nossos especialistas.',
+        content: `<p>As lentes de contato são uma alternativa prática aos óculos para os moradores de Caratinga. Nossa equipe orienta sobre higienização, adaptação e acompanhamento para garantir conforto e segurança.</p>`
+      },
+      en: {
+        title: 'Contact Lenses in Caratinga: A Beginner\'s Guide',
+        excerpt: 'Learn how to choose and care for contact lenses in Caratinga with tips from our specialists.',
+        content: `<p>Contact lenses are a practical alternative to glasses for residents of Caratinga. Our team guides you on hygiene, adaptation and follow-up to ensure comfort and safety.</p>`
+      }
+    }
+  }
+];
+
+export default blogPosts;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -5,6 +5,7 @@
     "about": "About Us",
     "testimonials": "Testimonials",
     "contact": "Contact",
+    "blog": "Blog",
     "faq": "FAQ",
     "lenses": "Lenses",
     "schedule": "Schedule",
@@ -557,6 +558,22 @@
     "title": "📋 Privacy Policy | Saraiva Vision | LGPD Compliance",
     "description": "📄 Saraiva Vision Clinic Privacy Policy according to LGPD. 🔒 How we protect your personal data and medical information in Caratinga/MG Brazil.",
     "keywords": "Saraiva Vision privacy policy, LGPD ophthalmology clinic, medical data protection, patient privacy Caratinga Brazil"
+  },
+  "blog": {
+    "tag": "Health Education",
+    "title": "Saraiva Vision Blog in Caratinga",
+    "subtitle": "Articles about eye health, treatments and news in Caratinga, Brazil.",
+    "view_all": "View all articles",
+    "read_more": "Read more",
+    "placeholder_title": "Content coming soon",
+    "placeholder_desc": "Soon you'll read tips and news about eye care.",
+    "placeholder_desc_page": "We're preparing articles focused on Caratinga, Brazil.",
+    "page_title": "Eye Health Blog in Caratinga",
+    "page_description": "Ophthalmology tips and local news for Caratinga and nearby cities.",
+    "page_subtitle": "Learn more about eye care in our city.",
+    "post_error_title": "Post not found",
+    "post_error_desc": "We couldn't load this content.",
+    "back_to_blog": "Back to blog"
   },
   "reviews": {
     "title": "Google Reviews",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -137,44 +137,20 @@
     }
   },
   "blog": {
-    "badge": "Educação em Saúde",
-    "title": "Blog Saraiva Vision",
-    "subtitle": "Artigos educativos sobre saúde ocular, tratamentos e novidades da oftalmologia para manter você bem informado.",
-    "featured": "Destaque",
-    "readMore": "Ler Artigo",
-    "categories": {
-      "all": "Todos",
-      "prevention": "Prevenção",
-      "treatments": "Tratamentos",
-      "pediatric": "Pediatria",
-      "technology": "Tecnologia"
-    },
-    "posts": {
-      "dryEyes": {
-        "title": "Síndrome do Olho Seco: Sintomas e Tratamentos",
-        "excerpt": "Entenda as causas da síndrome do olho seco e conheça as opções de tratamento mais eficazes para aliviar os sintomas."
-      },
-      "cataract": {
-        "title": "Cirurgia de Catarata: Guia Completo",
-        "excerpt": "Tudo que você precisa saber sobre a cirurgia de catarata, desde a preparação até o pós-operatório."
-      },
-      "childEyes": {
-        "title": "Cuidados com a Visão Infantil",
-        "excerpt": "Como identificar problemas visuais em crianças e a importância do acompanhamento oftalmológico desde cedo."
-      },
-      "technology": {
-        "title": "Novas Tecnologias em Oftalmologia",
-        "excerpt": "Conheça as mais recentes inovações tecnológicas que estão revolucionando os tratamentos oftalmológicos."
-      }
-    },
-    "newsletter": {
-      "title": "Receba conteúdo exclusivo",
-      "description": "Assine nossa newsletter e receba artigos sobre saúde ocular direto no seu e-mail.",
-      "emailPlaceholder": "Digite seu e-mail",
-      "subscribe": "Assinar",
-      "privacy": "Respeitamos sua privacidade. Sem spam."
-    },
-    "visitBlog": "Visitar Blog Completo"
+    "tag": "Educação em Saúde",
+    "title": "Blog Saraiva Vision em Caratinga",
+    "subtitle": "Artigos sobre saúde ocular, tratamentos e novidades em Caratinga e região.",
+    "view_all": "Ver todos os artigos",
+    "read_more": "Continuar lendo",
+    "placeholder_title": "Conteúdo em preparação",
+    "placeholder_desc": "Em breve dicas e notícias sobre saúde ocular.",
+    "placeholder_desc_page": "Estamos preparando artigos com foco em Caratinga MG.",
+    "page_title": "Blog de Saúde Visual em Caratinga",
+    "page_description": "Dicas de oftalmologia e notícias locais para Caratinga e região.",
+    "page_subtitle": "Saiba mais sobre cuidados com os olhos na nossa cidade.",
+    "post_error_title": "Publicação não encontrada",
+    "post_error_desc": "Não foi possível carregar este conteúdo.",
+    "back_to_blog": "Voltar para o blog"
   },
   "testimonials": {
     "badge": "Depoimentos",

--- a/src/pages/BlogPage.jsx
+++ b/src/pages/BlogPage.jsx
@@ -9,6 +9,7 @@ import { Calendar, Loader2, AlertTriangle, ArrowRight } from 'lucide-react';
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
 import { Button } from '@/components/ui/button';
+import blogPosts from '@/lib/blogPosts';
 
 const BlogPage = ({ wordpressUrl }) => {
   const { t, i18n } = useTranslation();
@@ -18,6 +19,7 @@ const BlogPage = ({ wordpressUrl }) => {
 
   useEffect(() => {
     if (!wordpressUrl) {
+      setPosts(blogPosts);
       setLoading(false);
       return;
     }
@@ -53,7 +55,7 @@ const BlogPage = ({ wordpressUrl }) => {
       );
     }
 
-    if (error || !wordpressUrl) {
+    if (error || posts.length === 0) {
       return (
         <div className="text-center p-12 bg-yellow-50 border border-yellow-200 rounded-2xl max-w-2xl mx-auto">
           <AlertTriangle className="h-12 w-12 text-yellow-500 mx-auto mb-4" />
@@ -65,39 +67,49 @@ const BlogPage = ({ wordpressUrl }) => {
 
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-        {posts.map((post, index) => (
-          <motion.article
-            key={post.id}
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, delay: index * 0.1 }}
-            className="modern-card overflow-hidden flex flex-col"
-          >
-            <Link to={`/blog/${post.slug}`} className="block overflow-hidden">
-              <img
-                src={post._embedded?.['wp:featuredmedia']?.[0]?.source_url || 'https://placehold.co/600x400/e2e8f0/64748b?text=Image'}
-                alt={post.title.rendered}
-                className="w-full h-56 object-cover transition-transform duration-300 hover:scale-105"
-              />
-            </Link>
-            <div className="p-6 flex flex-col flex-grow">
-              <div className="flex items-center text-sm text-gray-500 mb-3">
-                <Calendar className="w-4 h-4 mr-2" />
-                <span>{format(new Date(post.date), 'dd MMMM, yyyy', { locale: getDateLocale() })}</span>
-              </div>
-              <h3 className="text-xl font-bold mb-3 text-gray-900 flex-grow">
-                <Link to={`/blog/${post.slug}`} className="hover:text-blue-600" dangerouslySetInnerHTML={{ __html: post.title.rendered }} />
-              </h3>
-              <div className="text-gray-600 mb-4 text-sm" dangerouslySetInnerHTML={{ __html: post.excerpt.rendered.substring(0, 120) + '...' }} />
-              <Link to={`/blog/${post.slug}`} className="mt-auto">
-                <Button variant="link" className="p-0 text-blue-600 font-semibold group">
-                  {t('blog.read_more')}
-                  <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
-                </Button>
+        {posts.map((post, index) => {
+          const isWP = !!post.title?.rendered;
+          const title = isWP ? post.title.rendered : post.translations[i18n.language].title;
+          const excerpt = isWP
+            ? post.excerpt.rendered.replace(/<[^>]+>/g, '').substring(0, 120) + '...'
+            : post.translations[i18n.language].excerpt;
+          const image = isWP
+            ? post._embedded?.['wp:featuredmedia']?.[0]?.source_url
+            : post.image;
+          return (
+            <motion.article
+              key={post.id}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: index * 0.1 }}
+              className="modern-card overflow-hidden flex flex-col"
+            >
+              <Link to={`/blog/${post.slug}`} className="block overflow-hidden">
+                <img
+                  src={image || 'https://placehold.co/600x400/e2e8f0/64748b?text=Image'}
+                  alt={title}
+                  className="w-full h-56 object-cover transition-transform duration-300 hover:scale-105"
+                />
               </Link>
-            </div>
-          </motion.article>
-        ))}
+              <div className="p-6 flex flex-col flex-grow">
+                <div className="flex items-center text-sm text-gray-500 mb-3">
+                  <Calendar className="w-4 h-4 mr-2" />
+                  <span>{format(new Date(post.date), 'dd MMMM, yyyy', { locale: getDateLocale() })}</span>
+                </div>
+                <h3 className="text-xl font-bold mb-3 text-gray-900 flex-grow">
+                  <Link to={`/blog/${post.slug}`} className="hover:text-blue-600" dangerouslySetInnerHTML={{ __html: title }} />
+                </h3>
+                <div className="text-gray-600 mb-4 text-sm" dangerouslySetInnerHTML={{ __html: excerpt }} />
+                <Link to={`/blog/${post.slug}`} className="mt-auto">
+                  <Button variant="link" className="p-0 text-blue-600 font-semibold group">
+                    {t('blog.read_more')}
+                    <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
+                  </Button>
+                </Link>
+              </div>
+            </motion.article>
+          );
+        })}
       </div>
     );
   };


### PR DESCRIPTION
## Summary
- add blog routes and navigation link
- provide localized sample posts for Caratinga
- load blog content when WordPress is unavailable

## Testing
- `npx eslint src` (fails: module is not defined)
- `npm test` (fails: useLocation() may be used only in the context of a <Router> component)


------
https://chatgpt.com/codex/tasks/task_e_68b0ad3955b083288b6032d52bf4cef5