### PR TITLE
Refine Google Maps and Places integration

### DIFF
--- a/src/lib/__tests__/fetchPlaceDetails.test.js
+++ b/src/lib/__tests__/fetchPlaceDetails.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchPlaceDetails, clearPlaceCache } from '../fetchPlaceDetails';
+
+describe('fetchPlaceDetails', () => {
+  beforeEach(() => {
+    clearPlaceCache();
+    delete global.window;
+    delete global.google;
+  });
+
+  it('throws when Google Places is not available', async () => {
+    global.window = {};
+    await expect(fetchPlaceDetails('abc')).rejects.toThrow('Google Places library not available');
+  });
+
+  it('fetches and caches place details', async () => {
+    const fetchFields = vi.fn().mockResolvedValue();
+    const placeInstance = {
+      fetchFields,
+      displayName: 'Clinic',
+      location: { lat: 1, lng: 2 },
+      formattedAddress: 'Street 1',
+      rating: 4.5,
+      userRatingCount: 10,
+      googleMapsURI: 'http://maps.example'
+    };
+    const Place = vi.fn().mockImplementation(() => placeInstance);
+    global.window = {};
+    global.google = { maps: { places: { Place } } };
+
+    const first = await fetchPlaceDetails('id');
+    expect(first.name).toBe('Clinic');
+    expect(Place).toHaveBeenCalledTimes(1);
+
+    const second = await fetchPlaceDetails('id');
+    expect(Place).toHaveBeenCalledTimes(1);
+    expect(fetchFields).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+  });
+});

--- a/src/lib/__tests__/loadGoogleMaps.test.js
+++ b/src/lib/__tests__/loadGoogleMaps.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadGoogleMaps, resetGoogleMapsLoader } from '../loadGoogleMaps';
+
+describe('loadGoogleMaps', () => {
+  beforeEach(() => {
+    resetGoogleMapsLoader();
+    global.window = {};
+    global.document = {
+      querySelector: vi.fn(),
+      head: { appendChild: vi.fn() }
+    };
+    global.navigator = { onLine: true };
+  });
+
+  it('rejects when offline', async () => {
+    navigator.onLine = false;
+    await expect(loadGoogleMaps('key')).rejects.toThrow('Sem conexão com a internet');
+  });
+});

--- a/src/lib/fetchPlaceDetails.js
+++ b/src/lib/fetchPlaceDetails.js
@@ -1,0 +1,30 @@
+const placeCache = new Map();
+
+export function clearPlaceCache() {
+  placeCache.clear();
+}
+
+export async function fetchPlaceDetails(placeId, fields = ['displayName', 'location', 'formattedAddress', 'rating', 'userRatingCount', 'googleMapsURI']) {
+  if (!placeId) throw new Error('Place ID required');
+  if (placeCache.has(placeId)) return placeCache.get(placeId);
+
+  if (!(window?.google?.maps?.places?.Place)) {
+    throw new Error('Google Places library not available');
+  }
+
+  const { Place } = window.google.maps.places;
+  const place = new Place({ id: placeId, requestedLanguage: 'pt-BR' });
+  await place.fetchFields({ fields });
+
+  const data = {
+    name: place.displayName,
+    location: place.location,
+    formattedAddress: place.formattedAddress,
+    rating: place.rating,
+    userRatingCount: place.userRatingCount,
+    url: place.googleMapsURI
+  };
+
+  placeCache.set(placeId, data);
+  return data;
+}

--- a/src/lib/loadGoogleMaps.js
+++ b/src/lib/loadGoogleMaps.js
@@ -3,7 +3,14 @@ let loadCount = 0;
 
 // Google Maps API v3 loader with official callback pattern - eliminates warnings
 export function loadGoogleMaps(apiKey) {
-  if (typeof window === 'undefined') return Promise.reject(new Error('Window not available'));
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('Window not available'));
+  }
+
+  if (!navigator.onLine) {
+    return Promise.reject(new Error('Sem conexão com a internet'));
+  }
+
   if (window.google && window.google.maps) return Promise.resolve(window.google.maps);
   if (mapsPromise) return mapsPromise;
   if (!apiKey) return Promise.reject(new Error('Google Maps API key ausente'));
@@ -57,4 +64,10 @@ export function loadGoogleMaps(apiKey) {
   });
 
   return mapsPromise;
+}
+
+// For tests or hard resets
+export function resetGoogleMapsLoader() {
+  mapsPromise = null;
+  loadCount = 0;
 }


### PR DESCRIPTION
## Summary
- refactor map component to reuse cached Place details
- add utility to load Google Maps with offline detection and reset helper
- cover Google Maps loader and Place details with unit tests

## Testing
- `npx eslint -c .eslintrc.json --no-eslintrc src` (errors: Unexpected use of 'confirm', Unexpected use of 'addEventListener')
- `npm test` (fail: useLocation() may be used only in the context of a <Router> component; useContactSEO is not a function)


------
https://chatgpt.com/codex/tasks/task_e_68b2fbf6d6288328859c50a072dd6127