### PR TITLE
feat(api): send contact emails via Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ VITE_GOOGLE_PLACE_ID=your_google_place_id_here
 GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
 GOOGLE_PLACES_API_KEY=your_google_places_api_key_here
 GOOGLE_PLACE_ID=your_google_place_id_here
+RESEND_API_KEY=your_resend_api_key_here
+CONTACT_FROM_EMAIL=no-reply@yourdomain.com
+CONTACT_TO_EMAIL=contato@saraivavision.com.br
 
 # Supabase Configuration
 # 📚 Get these from your Supabase project dashboard: https://app.supabase.com

--- a/api/__tests__/contact.test.js
+++ b/api/__tests__/contact.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import handler from '../contact.js';
+
+vi.mock('resend', () => {
+  const send = vi.fn().mockResolvedValue({ id: '1' });
+  return {
+    Resend: vi.fn().mockImplementation(() => ({
+      emails: { send }
+    }))
+  };
+});
+
+const mockReqRes = (body = {}) => {
+  const req = {
+    method: 'POST',
+    body,
+    headers: {},
+    connection: { remoteAddress: '127.0.0.1' }
+  };
+  const res = {
+    statusCode: 200,
+    headers: {},
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    }
+  };
+  return { req, res };
+};
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({
+    json: () => Promise.resolve({ success: true, score: 0.9 })
+  });
+  process.env.RESEND_API_KEY = 'test';
+  process.env.CONTACT_FROM_EMAIL = 'from@example.com';
+  process.env.CONTACT_TO_EMAIL = 'to@example.com';
+  process.env.RECAPTCHA_SECRET_KEY = 'recaptcha';
+  delete global.rateLimitStore;
+});
+
+describe('contact API handler', () => {
+  it('rejects missing fields', async () => {
+    const { req, res } = mockReqRes({});
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.payload.error).toBe('Missing required fields');
+  });
+
+  it('sanitizes input and sends email', async () => {
+    const { Resend } = await import('resend');
+    const { req, res } = mockReqRes({
+      name: '<b>Ana</b>',
+      email: 'ana@example.com',
+      phone: '(33) 99999-9999',
+      message: 'Ola<script>alert(1)</script>',
+      consent: true,
+      recaptchaToken: 'token'
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const resendInstance = Resend.mock.instances[0];
+    expect(resendInstance.emails.send).toHaveBeenCalled();
+    const args = resendInstance.emails.send.mock.calls[0][0];
+    expect(args.html).not.toContain('<script>');
+  });
+});
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-helmet-async": "^2.0.5",
         "react-i18next": "^14.1.2",
         "react-router-dom": "^6.16.0",
+        "resend": "^6.0.2",
         "tailwind-merge": "^1.14.0",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -8805,6 +8806,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.0.2.tgz",
+      "integrity": "sha512-um08qWpSVvEVqAePEy/bsa7pqtnJK+qTCZ0Et7YE7xuqM46J0C9gnSbIJKR3LIcRVMgO9jUeot8rH0UI84eqMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-email/render": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-helmet-async": "^2.0.5",
     "react-i18next": "^14.1.2",
     "react-router-dom": "^6.16.0",
+    "resend": "^6.0.2",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.7"
   },


### PR DESCRIPTION
## Summary
- integrate Resend email service into contact form API with input sanitization and validation
- document Resend usage and environment variables
- add tests for contact API handler

## Testing
- `npx eslint --no-eslintrc -c .eslintrc.json src api` *(fails: Import in body of module; Unexpected use of 'confirm', etc.)*
- `npm test` *(fails: useLocation hook outside Router, safeNavigation utility tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fb18d45c832883de08925e732114