### PR TITLE
feat(security): add local rate limiting and injection checks

### DIFF
--- a/api/contact.js
+++ b/api/contact.js
@@ -81,6 +81,12 @@ export default async function handler(req, res) {
       return res.status(400).json({ error: 'Suspicious content in message' });
     }
 
+    // Detect common injection patterns
+    const injectionPattern = /(\b(select|insert|update|delete|drop|union|create|alter|truncate|exec)\b|;|--)/i;
+    if (injectionPattern.test(`${sanitizedData.name} ${sanitizedData.email} ${sanitizedData.message}`)) {
+      return res.status(400).json({ error: 'Potential injection attack detected' });
+    }
+
     // Additional validation
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(sanitizedData.email)) {


### PR DESCRIPTION
## Summary
- add basic in-memory rate limiter to local API server to mitigate DDoS
- harden contact form API with injection pattern detection
- adjust contact form tests for new validation and add regression test

## Testing
- `npm test` *(fails: useFormValidation Hook > provides correct field state, provides correct field state for valid/touched fields, plus multiple SEO hook tests)*
- `npx eslint src` *(fails: Cannot read config file .eslintrc.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b3076f3ee483289a143d36e4f614e8