### PR TITLE
feat(blog): add comment section

### DIFF
--- a/src/components/CommentSection.jsx
+++ b/src/components/CommentSection.jsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const CommentSection = ({ postSlug }) => {
+  const { t } = useTranslation();
+  const storageKey = `comments-${postSlug}`;
+  const [comments, setComments] = useState([]);
+  const [name, setName] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem(storageKey);
+    if (stored) {
+      try {
+        setComments(JSON.parse(stored));
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, [storageKey]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!name.trim() || !message.trim()) return;
+    const newComments = [
+      ...comments,
+      { id: Date.now(), name: name.trim(), message: message.trim() }
+    ];
+    setComments(newComments);
+    localStorage.setItem(storageKey, JSON.stringify(newComments));
+    setName('');
+    setMessage('');
+  };
+
+  return (
+    <section className="mt-12" aria-labelledby="comments-title">
+      <h2 id="comments-title" className="text-2xl font-bold mb-4">
+        {t('comments.title')}
+      </h2>
+      {comments.length === 0 ? (
+        <p className="text-gray-500 mb-4">{t('comments.no_comments')}</p>
+      ) : (
+        <ul className="space-y-4 mb-8">
+          {comments.map((c) => (
+            <li key={c.id} className="border p-4 rounded">
+              <p className="font-semibold">{c.name}</p>
+              <p className="mt-2">{c.message}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+        <div>
+          <label
+            htmlFor="comment-name"
+            className="block text-sm font-medium text-gray-700"
+          >
+            {t('comments.name_label')}
+          </label>
+          <input
+            id="comment-name"
+            type="text"
+            className="mt-1 block w-full border rounded px-3 py-2"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="comment-message"
+            className="block text-sm font-medium text-gray-700"
+          >
+            {t('comments.message_label')}
+          </label>
+          <textarea
+            id="comment-message"
+            className="mt-1 block w-full border rounded px-3 py-2"
+            rows={4}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+        >
+          {t('comments.submit')}
+        </button>
+      </form>
+    </section>
+  );
+};
+
+export default CommentSection;

--- a/src/components/__tests__/CommentSection.test.jsx
+++ b/src/components/__tests__/CommentSection.test.jsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import CommentSection from '../CommentSection'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key) => {
+      const translations = {
+        'comments.title': 'Comentários',
+        'comments.no_comments': 'Ainda não há comentários',
+        'comments.name_label': 'Nome',
+        'comments.message_label': 'Comentário',
+        'comments.submit': 'Adicionar Comentário'
+      }
+      return translations[key] || key
+    }
+  })
+}))
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('CommentSection', () => {
+  it('allows users to add comments', () => {
+    render(<CommentSection postSlug="post" />)
+
+    fireEvent.change(screen.getByLabelText('Nome'), { target: { value: 'Ana' } })
+    fireEvent.change(screen.getByLabelText('Comentário'), { target: { value: 'Ótimo post!' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Adicionar Comentário' }))
+
+    expect(screen.getByText('Ana')).toBeInTheDocument()
+    expect(screen.getByText('Ótimo post!')).toBeInTheDocument()
+  })
+})

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -599,6 +599,13 @@
     "post_error_desc": "We couldn't load this content.",
     "back_to_blog": "Back to blog"
   },
+  "comments": {
+    "title": "Comments",
+    "no_comments": "No comments yet",
+    "name_label": "Name",
+    "message_label": "Comment",
+    "submit": "Add Comment"
+  },
   "reviews": {
     "title": "Google Reviews",
     "refresh": "Refresh",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -152,6 +152,13 @@
     "post_error_desc": "Não foi possível carregar este conteúdo.",
     "back_to_blog": "Voltar para o blog"
   },
+  "comments": {
+    "title": "Comentários",
+    "no_comments": "Ainda não há comentários",
+    "name_label": "Nome",
+    "message_label": "Comentário",
+    "submit": "Adicionar Comentário"
+  },
   "testimonials": {
     "badge": "Depoimentos",
     "title": "O que nossos pacientes dizem",

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -9,6 +9,7 @@ import { Calendar, User, ArrowLeft, Loader2, AlertTriangle } from 'lucide-react'
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
 import blogPosts from '@/lib/blogPosts';
+import CommentSection from '@/components/CommentSection';
 
 const PostPage = ({ wordpressUrl }) => {
   const { slug } = useParams();
@@ -137,6 +138,7 @@ const PostPage = ({ wordpressUrl }) => {
               className="prose lg:prose-xl max-w-none"
               dangerouslySetInnerHTML={{ __html: content }}
             />
+            <CommentSection postSlug={slug} />
           </motion.div>
         </div>
       </main>


### PR DESCRIPTION
## Summary
- add reusable CommentSection component storing comments in localStorage
- show comment section on blog posts
- translate new comment strings in both locales and add component test

## Testing
- `npx eslint src` *(fails: module is not defined in .eslintrc.js)*
- `npm test` *(fails: 16 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b307042edc832891b37b60bb31fd23