### PR TITLE
docs: document custom slash commands

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -9,6 +9,16 @@ the guidelines below when contributing:
 - Keep UI strings in `src/locales/en/translation.json` and
   `src/locales/pt/translation.json`.
 
+## Custom Slash Commands
+- `/dev` — run `npm run dev` to start the development server.
+- `/lint` — run `npx eslint src` to check code style.
+- `/test` — run `npm test` to execute unit tests.
+- `/build` — run `npm run build` for a production build.
+- `/preview` — run `npm run preview` to serve the build locally.
+- `/coverage` — run `npm run test:coverage` to generate a coverage report.
+- `/ci` — run `npx eslint src && npm test && npm run build` to mimic the CI pipeline.
+- `/deploy` — run `./deploy.sh` to deploy the built app with Nginx.
+
 ## CI/CD
 - GitHub Actions should lint, test, and build the app on every pull request.
 - Protect the `main` branch with required status checks.


### PR DESCRIPTION
## Summary
- document custom slash commands for common tasks including coverage, CI, and deployment steps

## Testing
- `npx eslint src` *(fails: ReferenceError: module is not defined)*
- `npm test -- --run` *(fails: tests failing, e.g., fetchPlaceDetails)*

------
https://chatgpt.com/codex/tasks/task_e_68b30d2edbe883289902879340edd96e