### PR TITLE
feat(contact-lenses): add environment-friendly badge

### DIFF
--- a/src/components/ContactLenses.jsx
+++ b/src/components/ContactLenses.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
-import { Check, ExternalLink, Shield, Users, Award, Eye, ChevronDown, MessageCircle, Star, Clock, Heart, Zap, Globe, Sparkles } from 'lucide-react';
+import { Check, ExternalLink, Shield, Users, Award, Eye, ChevronDown, MessageCircle, Star, Clock, Heart, Zap, Globe, Sparkles, Leaf } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import ContactLensesHeroImage from './ContactLensesHeroImage';
 
@@ -194,14 +194,15 @@ const ContactLenses = () => {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ delay: 0.3 }}
-            className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto"
+            className="grid grid-cols-2 md:grid-cols-5 gap-6 max-w-4xl mx-auto"
           >
             {Object.entries(trustBadges).map(([key, value], index) => {
               const icons = {
                 experience: Clock,
                 patients: Users,
                 safety: Shield,
-                brands: Award
+                brands: Award,
+                environment: Leaf
               };
               const Icon = icons[key] || Shield;
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -162,7 +162,8 @@
       "experience": "15+ Years Experience",
       "patients": "1000+ Successful Adaptations",
       "safety": "100% Sterile Procedures",
-      "brands": "Authorized Premium Brands"
+      "brands": "Authorized Premium Brands",
+      "environment": "Environment-Friendly Company"
     },
     "brands_section": {
       "title": "Premium Brands Available",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -314,7 +314,8 @@
       "experience": "15+ Anos de Experiência",
       "patients": "1000+ Adaptações Bem-sucedidas",
       "safety": "100% Procedimentos Estéreis",
-      "brands": "Marcas Premium Autorizadas"
+      "brands": "Marcas Premium Autorizadas",
+      "environment": "Empresa Amiga do Meio Ambiente"
     },
     "brands_section": {
       "title": "Marcas Premium Disponíveis",


### PR DESCRIPTION
## Summary
- add environment-friendly trust badge on contact lenses page
- translate environment badge text in English and Portuguese

## Testing
- `npx eslint src` *(fails: module is not defined in .eslintrc.js)*
- `npm test` *(fails: Failed to resolve import "react-helmet"; various test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b30f2c69348328adc1c1431bcfd6f6