### PR TITLE
feat(trust): add ISO 9001 certification badge

### DIFF
--- a/src/components/TrustSignals.jsx
+++ b/src/components/TrustSignals.jsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
-import { Shield, Award, Users, Clock, Heart, Star } from 'lucide-react';
+import { Shield, Award, Users, Clock, CheckCircle } from 'lucide-react';
 
 const TrustSignals = () => {
   const { t } = useTranslation();
 
   const trustItems = [
+    {
+      icon: CheckCircle,
+      title: t('trust.iso.title'),
+      description: t('trust.iso.description'),
+      color: 'blue'
+    },
     {
       icon: Award,
       title: t('trust.awards.title'),

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -40,6 +40,35 @@
     "microcopy_fast_confirmation": "Fill your details and get confirmation in 1 minute. 100% secure.",
     "more_contact_options": "Other contact options"
   },
+  "trust": {
+    "badge": "Trust & Quality",
+    "title": "Why choose Saraiva Vision?",
+    "subtitle": "Our reputation is built on years of excellence, advanced technology and genuine care.",
+    "awards": {
+      "title": "Awards",
+      "description": "Recognition for excellence in ophthalmology"
+    },
+    "patients": {
+      "title": "5,000+ Patients",
+      "description": "Served with satisfaction and quality"
+    },
+    "experience": {
+      "title": "15+ Years",
+      "description": "Of experience in eye care"
+    },
+    "iso": {
+      "title": "ISO 9001 Certified",
+      "description": "Recognized quality management system"
+    },
+    "partnerships": {
+      "sectionTitle": "Our Partners"
+    },
+    "stats": {
+      "satisfaction": "Satisfaction Rate",
+      "patients": "Patients Served",
+      "years": "Years of Experience"
+    }
+  },
   "services": {
     "title": "Our Services",
     "subtitle": "We offer a full range of ophthalmological services to care for your vision with the highest quality and technology.",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -55,6 +55,10 @@
       "title": "15+ Anos",
       "description": "De experiência em saúde ocular"
     },
+    "iso": {
+      "title": "Certificação ISO 9001",
+      "description": "Sistema de gestão da qualidade reconhecido"
+    },
     "partnerships": {
       "sectionTitle": "Nossos Parceiros"
     },


### PR DESCRIPTION
## Summary
- showcase ISO 9001 certification in trust signals
- localize ISO 9001 text for Portuguese and English users

## Testing
- `npm test` (fails: 14 failed, 6 passed)
- `npx eslint src` (fails: ReferenceError: Cannot read config file)


------
https://chatgpt.com/codex/tasks/task_e_68b30e3d4f708328b6f76551472aa89c