### PR TITLE
Fix Nginx SPA routing for blog pages

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -153,8 +153,8 @@ server {
         expires 1y;
         add_header Cache-Control "public, immutable, max-age=31536000";
         add_header Vary "Accept-Encoding";
-        include /etc/nginx/includes/security-headers.conf;
-        
+        include /etc/nginx/nginx-includes/security-headers.conf;
+
         # Performance optimizations
         tcp_nodelay on;
         tcp_nopush on;
@@ -168,12 +168,12 @@ server {
         expires 30d;
         add_header Cache-Control "public, max-age=2592000";
         add_header Accept-Ranges bytes;
-        
+
         # Range requests for streaming
         proxy_set_header Range $http_range;
         proxy_set_header If-Range $http_if_range;
-        
-        include /etc/nginx/includes/security-headers.conf;
+
+        include /etc/nginx/nginx-includes/security-headers.conf;
         try_files $uri =404;
     }
 
@@ -250,18 +250,6 @@ server {
         add_header Cache-Control "public, max-age=300" always;
         include /etc/nginx/nginx-includes/security-headers.conf;
         include /etc/nginx/nginx-includes/csp.conf;
-    }
-
-    location /blog/ {
-        proxy_pass http://127.0.0.1:8083/;
-        proxy_set_header Host "cms.saraivavision.com.br";
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Port 443;
-        proxy_redirect default;
-        proxy_redirect / /blog/;
     }
 
     location /cms/ {


### PR DESCRIPTION
## Summary
- update static asset and media blocks to include the correct shared security headers include path
- remove the legacy /blog reverse proxy so SPA routes fall through to index.html and are handled by React Router

## Testing
- ./validate-nginx-configs.sh

------
https://chatgpt.com/codex/tasks/task_e_68cb1a61672883289333f129ce9a448b