### PR TITLE
Add infrastructure diagnostics dashboard for check subdomain

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ const BlogPage = lazy(() => import('@/pages/BlogPage'));
 const PostPage = lazy(() => import('@/pages/PostPage'));
 const CategoryPage = lazy(() => import('@/pages/CategoryPage'));
 const AdminLoginPage = lazy(() => import('@/pages/AdminLoginPage'));
+const CheckPage = lazy(() => import('@/pages/CheckPage'));
 import ScrollToTop from '@/components/ScrollToTop';
 import ServiceRedirect from '@/components/ServiceRedirect';
 import { Toaster } from '@/components/ui/toaster';
@@ -35,6 +36,8 @@ import ScrollDiagnostics from '@/components/ScrollDiagnostics';
 
 function App() {
   const { i18n } = useTranslation();
+  const isCheckSubdomain =
+    typeof window !== 'undefined' && window.location.hostname?.toLowerCase().startsWith('check.');
 
   useEffect(() => {
     document.documentElement.lang = i18n.language;
@@ -57,7 +60,8 @@ function App() {
           <ScrollToTop />
           <Suspense fallback={<div className="w-full py-20 text-center text-sm text-slate-700">Carregando...</div>}>
             <Routes>
-              <Route path="/" element={<HomePage />} />
+              <Route path="/" element={isCheckSubdomain ? <CheckPage /> : <HomePage />} />
+              <Route path="/check" element={<CheckPage />} />
               <Route path="/servicos" element={<ServicesPage />} />
               <Route path="/servicos/:serviceId" element={<ServiceDetailPage />} />
               {/* Redirecionamentos 301 para padronização de URLs */}
@@ -75,6 +79,7 @@ function App() {
               <Route path="/admin" element={<AdminLoginPage />} />
               <Route path="/privacy" element={<PrivacyPolicyPage />} />
               <Route path="/wp-admin" element={<AdminPage />} />
+              {isCheckSubdomain ? <Route path="*" element={<Navigate to="/" replace />} /> : null}
             </Routes>
           </Suspense>
         </div>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1017,5 +1017,116 @@
     "read_more_post": "Read more about: {{title}}",
     "main_content_label": "Blog main content",
     "posts_section_label": "Blog posts"
+  },
+  "check": {
+    "badge": "Infrastructure monitor",
+    "title": "Saraiva Vision infrastructure diagnostics",
+    "subtitle": "Run real-time checks to validate connectivity, DNS, SSL, WordPress services and the check.saraivavision.com.br subdomain.",
+    "runButton": "Run diagnostics",
+    "running": "Running diagnostics...",
+    "resetButton": "Reset results",
+    "lastUpdated": "Last completed run: {{timestamp}}",
+    "neverRun": "Diagnostics have not been executed yet.",
+    "perCheckUpdated": "Updated {{timestamp}}",
+    "waiting": "Awaiting execution.",
+    "status": {
+      "idle": "Idle",
+      "running": "Running",
+      "success": "Operational",
+      "warning": "Attention",
+      "error": "Error"
+    },
+    "seo": {
+      "title": "Infrastructure Diagnostics | Saraiva Vision",
+      "description": "Real-time infrastructure monitoring for Saraiva Vision covering DNS, SSL, API routes and WordPress services.",
+      "keywords": "infrastructure monitoring, dns check, ssl check, wordpress api health, saraiva vision"
+    },
+    "messages": {
+      "browserOnly": "Diagnostics require a browser environment.",
+      "timeout": "Request timed out before receiving a response.",
+      "fetchError": "Network request failed: {{message}}",
+      "httpError": "Unexpected HTTP status: {{status}}",
+      "opaqueResponse": "Connection succeeded but response details are hidden by CORS restrictions.",
+      "missingRoutes": "Some API routes are not available: {{missing}}.",
+      "hostMismatch": "Current host is {{hostname}}. Point the DNS to {{expected}} to use this dashboard.",
+      "insecureProtocol": "Connection is using {{protocol}}. Enable HTTPS for full coverage.",
+      "hostnameUnavailable": "Could not detect the current hostname.",
+      "unexpected": "Unexpected error: {{message}}"
+    },
+    "diagnostics": {
+      "server": {
+        "title": "Server reachability",
+        "description": "Checks if {{target}} responds over HTTPS.",
+        "success": "The server responded successfully in {{latency}}.",
+        "error": "Unable to reach {{target}}. Investigate DNS and networking."
+      },
+      "services": {
+        "title": "WordPress services",
+        "description": "Tests the availability of published pages via the WordPress API.",
+        "success": "API returned {{count}} page entries in {{latency}}.",
+        "warning": "Service reached but the response could not be inspected (likely CORS).",
+        "error": "The WordPress page endpoint did not respond correctly."
+      },
+      "api": {
+        "title": "Blog/posts API",
+        "description": "Requests the latest posts from the headless WordPress instance.",
+        "success": "Received {{count}} post entry in {{latency}}.",
+        "warning": "Connection established but response details were blocked.",
+        "error": "The posts endpoint is unavailable."
+      },
+      "routes": {
+        "title": "API route registry",
+        "description": "Validates WordPress REST routes for posts, pages and categories.",
+        "success": "All critical routes are registered ({{totalRoutes}} total).",
+        "warning": "Missing REST routes detected: {{missing}}.",
+        "error": "Could not load the REST route registry."
+      },
+      "dns": {
+        "title": "DNS resolution",
+        "description": "Queries public DNS for {{hostname}} A records.",
+        "success": "DNS returned {{count}} record(s).",
+        "warning": "No DNS A records were returned.",
+        "error": "DNS query failed.",
+        "recordsLabel": "Resolved IP addresses"
+      },
+      "ip": {
+        "title": "IP addresses",
+        "description": "Collects IPv4 and IPv6 records for {{hostname}}.",
+        "success": "Active IP addresses resolved.",
+        "warning": "No IP addresses were returned by DNS.",
+        "error": "Failed to resolve IP addresses.",
+        "ipv4Label": "IPv4",
+        "ipv6Label": "IPv6"
+      },
+      "ssl": {
+        "title": "SSL handshake",
+        "description": "Ensures {{target}} accepts HTTPS connections.",
+        "success": "Secure connection established.",
+        "error": "HTTPS connection failed."
+      },
+      "subdomain": {
+        "title": "Subdomain binding",
+        "description": "Confirms that the dashboard is served from {{expected}}.",
+        "success": "Dashboard served from {{hostname}}.",
+        "warning": "Subdomain not pointed to {{expected}} yet."
+      },
+      "php": {
+        "title": "PHP routes / WordPress bootstrap",
+        "description": "Calls the REST bootstrap endpoint to confirm PHP routing.",
+        "success": "WordPress namespace {{namespace}} responded ({{routes}} routes available).",
+        "warning": "Endpoint reachable but response details were hidden.",
+        "error": "Unable to reach the PHP routing endpoint.",
+        "routesLabel": "Routes exposed: {{routes}}"
+      },
+      "nginx": {
+        "title": "Nginx headers",
+        "description": "Inspects response headers from the WordPress API endpoint.",
+        "success": "Server header indicates {{server}}.",
+        "warning": "Headers hidden by CORS; confirm exposure on the server.",
+        "error": "Unable to inspect Nginx headers.",
+        "serverLabel": "Server header: {{server}}"
+      }
+    }
   }
 }
+

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -1113,5 +1113,115 @@
     "loggingIn": "Entrando...",
     "loginError": "Erro ao fazer login. Verifique suas credenciais.",
     "backToBlog": "Voltar ao Blog"
+  },
+  "check": {
+    "badge": "Monitoramento de infraestrutura",
+    "title": "Diagnóstico da infraestrutura Saraiva Vision",
+    "subtitle": "Execute verificações em tempo real para validar conectividade, DNS, SSL, serviços WordPress e o subdomínio check.saraivavision.com.br.",
+    "runButton": "Executar diagnósticos",
+    "running": "Executando diagnósticos...",
+    "resetButton": "Limpar resultados",
+    "lastUpdated": "Última execução concluída: {{timestamp}}",
+    "neverRun": "Os diagnósticos ainda não foram executados.",
+    "perCheckUpdated": "Atualizado em {{timestamp}}",
+    "waiting": "Aguardando execução.",
+    "status": {
+      "idle": "Parado",
+      "running": "Em execução",
+      "success": "Operacional",
+      "warning": "Atenção",
+      "error": "Erro"
+    },
+    "seo": {
+      "title": "Diagnóstico de Infraestrutura | Saraiva Vision",
+      "description": "Monitoramento em tempo real da infraestrutura digital da Saraiva Vision: DNS, SSL, API e serviços WordPress.",
+      "keywords": "monitoramento infraestrutura, verificação dns, verificação ssl, saúde api wordpress, saraiva vision"
+    },
+    "messages": {
+      "browserOnly": "Os diagnósticos precisam ser executados em um navegador.",
+      "timeout": "A requisição expirou antes de receber resposta.",
+      "fetchError": "Falha na requisição: {{message}}",
+      "httpError": "Status HTTP inesperado: {{status}}",
+      "opaqueResponse": "Conexão realizada, mas os detalhes foram bloqueados por CORS.",
+      "missingRoutes": "Algumas rotas da API não estão disponíveis: {{missing}}.",
+      "hostMismatch": "Host atual é {{hostname}}. Aponte o DNS para {{expected}} para usar este painel.",
+      "insecureProtocol": "A conexão está usando {{protocol}}. Habilite HTTPS para cobertura completa.",
+      "hostnameUnavailable": "Não foi possível detectar o hostname atual.",
+      "unexpected": "Erro inesperado: {{message}}"
+    },
+    "diagnostics": {
+      "server": {
+        "title": "Disponibilidade do servidor",
+        "description": "Verifica se {{target}} responde em HTTPS.",
+        "success": "O servidor respondeu com sucesso em {{latency}}.",
+        "error": "Não foi possível alcançar {{target}}. Verifique DNS e rede."
+      },
+      "services": {
+        "title": "Serviços WordPress",
+        "description": "Testa a disponibilidade das páginas publicadas via API do WordPress.",
+        "success": "A API retornou {{count}} páginas em {{latency}}.",
+        "warning": "Serviço alcançado, mas não foi possível inspecionar a resposta (provável CORS).",
+        "error": "O endpoint de páginas do WordPress não respondeu corretamente."
+      },
+      "api": {
+        "title": "API de posts/blog",
+        "description": "Solicita os posts mais recentes do WordPress headless.",
+        "success": "Recebido {{count}} post em {{latency}}.",
+        "warning": "Conexão estabelecida, mas os detalhes foram bloqueados.",
+        "error": "O endpoint de posts está indisponível."
+      },
+      "routes": {
+        "title": "Registro de rotas da API",
+        "description": "Valida as rotas REST do WordPress para posts, páginas e categorias.",
+        "success": "Todas as rotas críticas estão registradas ({{totalRoutes}} no total).",
+        "warning": "Rotas REST ausentes: {{missing}}.",
+        "error": "Não foi possível carregar o registro de rotas REST."
+      },
+      "dns": {
+        "title": "Resolução DNS",
+        "description": "Consulta servidores DNS públicos pelos registros A de {{hostname}}.",
+        "success": "DNS retornou {{count}} registro(s).",
+        "warning": "Nenhum registro A foi retornado.",
+        "error": "Falha na consulta DNS.",
+        "recordsLabel": "IPs resolvidos"
+      },
+      "ip": {
+        "title": "Endereços IP",
+        "description": "Coleta registros IPv4 e IPv6 de {{hostname}}.",
+        "success": "Endereços IP ativos resolvidos.",
+        "warning": "Nenhum endereço IP foi retornado pelo DNS.",
+        "error": "Falha ao resolver os endereços IP.",
+        "ipv4Label": "IPv4",
+        "ipv6Label": "IPv6"
+      },
+      "ssl": {
+        "title": "Handshake SSL",
+        "description": "Garante que {{target}} aceita conexões HTTPS.",
+        "success": "Conexão segura estabelecida.",
+        "error": "Falha na conexão HTTPS."
+      },
+      "subdomain": {
+        "title": "Vinculação do subdomínio",
+        "description": "Confirma que o painel está servido por {{expected}}.",
+        "success": "Painel servido a partir de {{hostname}}.",
+        "warning": "Subdomínio ainda não aponta para {{expected}}."
+      },
+      "php": {
+        "title": "Rotas PHP / bootstrap do WordPress",
+        "description": "Chama o endpoint de bootstrap REST para confirmar o roteamento em PHP.",
+        "success": "Namespace {{namespace}} respondeu ({{routes}} rotas disponíveis).",
+        "warning": "Endpoint acessível, mas sem acesso aos detalhes.",
+        "error": "Não foi possível acessar o endpoint de roteamento PHP.",
+        "routesLabel": "Rotas expostas: {{routes}}"
+      },
+      "nginx": {
+        "title": "Cabeçalhos do Nginx",
+        "description": "Inspeciona os cabeçalhos da resposta no endpoint da API do WordPress.",
+        "success": "Cabeçalho do servidor indica {{server}}.",
+        "warning": "Cabeçalhos ocultos por CORS; confirme a exposição no servidor.",
+        "error": "Não foi possível inspecionar os cabeçalhos do Nginx.",
+        "serverLabel": "Cabeçalho Server: {{server}}"
+      }
+    }
   }
 }

--- a/src/pages/CheckPage.jsx
+++ b/src/pages/CheckPage.jsx
@@ -1,0 +1,355 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import Navbar from '@/components/Navbar';
+import Footer from '@/components/Footer';
+import SEOHead from '@/components/SEOHead';
+import { useTranslation } from 'react-i18next';
+import createDiagnostics from '@/utils/systemDiagnostics';
+
+const statusStyles = {
+  idle: 'bg-slate-200 text-slate-700',
+  running: 'bg-blue-100 text-blue-700',
+  success: 'bg-emerald-100 text-emerald-700',
+  warning: 'bg-amber-100 text-amber-700',
+  error: 'bg-rose-100 text-rose-700',
+};
+
+const dotStyles = {
+  idle: 'bg-slate-400',
+  running: 'bg-blue-500',
+  success: 'bg-emerald-500',
+  warning: 'bg-amber-500',
+  error: 'bg-rose-500',
+};
+
+const formatLatency = (value) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null;
+  }
+
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(2)} s`;
+  }
+
+  return `${Math.round(value)} ms`;
+};
+
+const formatTimestamp = (isoString) => {
+  if (!isoString) return null;
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString(undefined, {
+    dateStyle: 'short',
+    timeStyle: 'medium',
+  });
+};
+
+const createEmptyState = (definitions) => {
+  return definitions.reduce((acc, definition) => {
+    acc[definition.id] = {
+      status: 'idle',
+      data: null,
+      messageId: null,
+      messageParams: null,
+      latency: null,
+      lastRun: null,
+    };
+    return acc;
+  }, {});
+};
+
+const CheckPage = () => {
+  const { t, i18n } = useTranslation();
+  const diagnostics = useMemo(() => createDiagnostics(), []);
+  const [results, setResults] = useState(() => createEmptyState(diagnostics));
+  const [isRunning, setIsRunning] = useState(false);
+  const [lastCompletedAt, setLastCompletedAt] = useState(null);
+  const seo = useMemo(
+    () => ({
+      title: t('check.seo.title'),
+      description: t('check.seo.description'),
+      keywords: t('check.seo.keywords'),
+    }),
+    [t, i18n.language]
+  );
+
+  useEffect(() => {
+    setResults(createEmptyState(diagnostics));
+  }, [diagnostics]);
+
+  const runDiagnostics = useCallback(async () => {
+    if (isRunning) return;
+
+    setIsRunning(true);
+
+    for (const definition of diagnostics) {
+      setResults((prev) => ({
+        ...prev,
+        [definition.id]: {
+          ...prev[definition.id],
+          status: 'running',
+          data: null,
+          messageId: null,
+          messageParams: null,
+          latency: null,
+        },
+      }));
+
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const outcome = await definition.run();
+        setResults((prev) => ({
+          ...prev,
+          [definition.id]: {
+            status: outcome.status ?? 'error',
+            data: outcome.data ?? null,
+            messageId: outcome.messageId || null,
+            messageParams: outcome.messageParams || null,
+            latency: typeof outcome.latency === 'number' ? outcome.latency : null,
+            lastRun: new Date().toISOString(),
+          },
+        }));
+      } catch (error) {
+        setResults((prev) => ({
+          ...prev,
+          [definition.id]: {
+            status: 'error',
+            data: null,
+            messageId: 'unexpected',
+            messageParams: { message: error?.message || 'Unknown error' },
+            latency: null,
+            lastRun: new Date().toISOString(),
+          },
+        }));
+      }
+    }
+
+    setLastCompletedAt(new Date().toISOString());
+    setIsRunning(false);
+  }, [diagnostics, isRunning]);
+
+  useEffect(() => {
+    runDiagnostics();
+  }, [runDiagnostics]);
+
+  const resetResults = () => {
+    if (isRunning) return;
+    setResults(createEmptyState(diagnostics));
+    setLastCompletedAt(null);
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-slate-50">
+      <SEOHead {...seo} />
+      <Navbar />
+      <main className="flex-1 pt-28 pb-20">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col gap-6">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-500 font-semibold">
+                {t('check.badge')}
+              </p>
+              <h1 className="mt-2 text-3xl md:text-4xl font-bold text-slate-900">
+                {t('check.title')}
+              </h1>
+              <p className="mt-4 text-base md:text-lg text-slate-600 max-w-3xl">
+                {t('check.subtitle')}
+              </p>
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-sm text-slate-600">
+                {lastCompletedAt
+                  ? t('check.lastUpdated', { timestamp: formatTimestamp(lastCompletedAt) })
+                  : t('check.neverRun')}
+              </div>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <button
+                  type="button"
+                  onClick={runDiagnostics}
+                  disabled={isRunning}
+                  className={`inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600 ${
+                    isRunning
+                      ? 'bg-emerald-200 text-emerald-700 cursor-not-allowed'
+                      : 'bg-emerald-600 text-white hover:bg-emerald-500'
+                  }`}
+                >
+                  {isRunning ? t('check.running') : t('check.runButton')}
+                </button>
+                <button
+                  type="button"
+                  onClick={resetResults}
+                  disabled={isRunning}
+                  className="inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-semibold text-slate-700 bg-white border border-slate-200 shadow-sm hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 disabled:cursor-not-allowed disabled:opacity-70"
+                >
+                  {t('check.resetButton')}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-10 grid gap-6 md:grid-cols-2">
+            {diagnostics.map((definition) => {
+              const result = results[definition.id];
+              const status = result?.status || 'idle';
+              const statusLabel = t(`check.status.${status}`);
+              const translationParams = {
+                ...definition.defaultParams,
+                ...(result?.data || {}),
+              };
+              const latencyLabel = formatLatency(result?.latency);
+              if (latencyLabel) {
+                translationParams.latency = latencyLabel;
+              }
+              const countValue =
+                typeof result?.data?.count === 'number'
+                  ? result.data.count
+                  : Array.isArray(result?.data?.records)
+                    ? result.data.records.length
+                    : undefined;
+              if (typeof countValue === 'number') {
+                translationParams.count = countValue;
+              }
+              if (typeof result?.data?.totalRoutes === 'number') {
+                translationParams.totalRoutes = result.data.totalRoutes;
+              }
+              const missingRoutes = Array.isArray(result?.data?.missingRoutes)
+                ? result.data.missingRoutes.join(', ')
+                : result?.messageParams?.missing;
+              if (missingRoutes) {
+                translationParams.missing = missingRoutes;
+              }
+
+              const detailsKey = `check.diagnostics.${definition.id}.${status}`;
+              const detailsText = t(detailsKey, {
+                defaultValue: '',
+                ...translationParams,
+              });
+              const hasCustomDetails = detailsText && detailsText !== detailsKey;
+
+              const messageText = result?.messageId
+                ? t(`check.messages.${result.messageId}`, {
+                    ...definition.defaultParams,
+                    ...(result?.messageParams || {}),
+                    ...(result?.data || {}),
+                    missing: translationParams.missing,
+                    hostname: result?.data?.hostname || definition.defaultParams?.expected,
+                  })
+                : null;
+
+              return (
+                <div
+                  key={definition.id}
+                  className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6 flex flex-col gap-4"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <h2 className="text-lg font-semibold text-slate-900">
+                        {t(`check.diagnostics.${definition.id}.title`)}
+                      </h2>
+                      <p className="mt-1 text-sm text-slate-600">
+                        {t(`check.diagnostics.${definition.id}.description`, definition.defaultParams)}
+                      </p>
+                    </div>
+                    <span
+                      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${
+                        statusStyles[status] || statusStyles.idle
+                      }`}
+                    >
+                      <span className={`h-2 w-2 rounded-full ${dotStyles[status] || dotStyles.idle}`} />
+                      {statusLabel}
+                    </span>
+                  </div>
+
+                  <div className="text-sm text-slate-700">
+                    {status === 'idle' ? t('check.waiting') : null}
+                    {status === 'running' ? t('check.running') : null}
+                    {status !== 'idle' && status !== 'running' && hasCustomDetails ? (
+                      <p>{detailsText}</p>
+                    ) : null}
+                    {status !== 'idle' && status !== 'running' && !hasCustomDetails && messageText ? (
+                      <p>{messageText}</p>
+                    ) : null}
+                  </div>
+
+                  {messageText && (status === 'success' || status === 'warning') && hasCustomDetails ? (
+                    <div className="text-xs text-slate-500">
+                      {messageText}
+                    </div>
+                  ) : null}
+
+                  {definition.id === 'dns' && Array.isArray(result?.data?.records) && result.data.records.length > 0 ? (
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-slate-500 font-semibold">
+                        {t('check.diagnostics.dns.recordsLabel')}
+                      </p>
+                      <ul className="mt-2 space-y-1 text-sm text-slate-700">
+                        {result.data.records.map((record) => (
+                          <li key={record} className="font-mono text-xs bg-slate-100 px-2 py-1 rounded-md inline-block">
+                            {record}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+
+                  {definition.id === 'ip' && (result?.data?.ipv4?.length || result?.data?.ipv6?.length) ? (
+                    <div className="grid gap-2 text-sm text-slate-700">
+                      {Array.isArray(result?.data?.ipv4) && result.data.ipv4.length > 0 ? (
+                        <div>
+                          <p className="text-xs uppercase tracking-wide text-slate-500 font-semibold">
+                            {t('check.diagnostics.ip.ipv4Label')}
+                          </p>
+                          <ul className="mt-1 flex flex-wrap gap-2">
+                            {result.data.ipv4.map((record) => (
+                              <li key={`ipv4-${record}`} className="font-mono text-xs bg-slate-100 px-2 py-1 rounded-md">
+                                {record}
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      ) : null}
+                      {Array.isArray(result?.data?.ipv6) && result.data.ipv6.length > 0 ? (
+                        <div>
+                          <p className="text-xs uppercase tracking-wide text-slate-500 font-semibold">
+                            {t('check.diagnostics.ip.ipv6Label')}
+                          </p>
+                          <ul className="mt-1 flex flex-wrap gap-2">
+                            {result.data.ipv6.map((record) => (
+                              <li key={`ipv6-${record}`} className="font-mono text-xs bg-slate-100 px-2 py-1 rounded-md">
+                                {record}
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  {definition.id === 'php' && typeof result?.data?.routes === 'number' ? (
+                    <p className="text-xs text-slate-500">
+                      {t('check.diagnostics.php.routesLabel', { routes: result.data.routes })}
+                    </p>
+                  ) : null}
+
+                  {definition.id === 'nginx' && result?.data?.server ? (
+                    <p className="text-xs text-slate-500">
+                      {t('check.diagnostics.nginx.serverLabel', { server: result.data.server })}
+                    </p>
+                  ) : null}
+
+                  {result?.lastRun ? (
+                    <p className="text-xs text-slate-500">
+                      {t('check.perCheckUpdated', { timestamp: formatTimestamp(result.lastRun) })}
+                    </p>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default CheckPage;

--- a/src/utils/systemDiagnostics.js
+++ b/src/utils/systemDiagnostics.js
@@ -1,0 +1,761 @@
+const DEFAULT_TIMEOUT = 8000;
+
+const now = () => {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+};
+
+const stripTrailingSlash = (value) => {
+  if (typeof value !== 'string') return '';
+  return value.replace(/\/+$/, '');
+};
+
+const isBrowserEnvironment = () => typeof window !== 'undefined' && typeof fetch === 'function';
+
+async function fetchWithTimeout(url, options = {}) {
+  const { timeout = DEFAULT_TIMEOUT, ...rest } = options;
+
+  if (typeof fetch !== 'function') {
+    throw new Error('Fetch API is not available');
+  }
+
+  if (typeof AbortController === 'undefined' || timeout <= 0) {
+    return fetch(url, rest);
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    return await fetch(url, { ...rest, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function buildLatency(start) {
+  const end = now();
+  return end - start;
+}
+
+function resolveHostname(url) {
+  try {
+    return new URL(url).hostname;
+  } catch (error) {
+    return url;
+  }
+}
+
+export function createDiagnostics(customConfig = {}) {
+  const config = {
+    primaryDomain: 'https://saraivavision.com.br',
+    wordpressDomain: 'https://saraivavision.com.br',
+    checkHost: 'check.saraivavision.com.br',
+    dnsHostname: null,
+    ...customConfig,
+  };
+
+  const primaryDomain = stripTrailingSlash(config.primaryDomain || 'https://saraivavision.com.br');
+  const wordpressDomain = stripTrailingSlash(config.wordpressDomain || primaryDomain);
+  const wordpressRestBase = `${wordpressDomain}/wp-json/wp/v2`;
+  const wordpressRoot = `${wordpressDomain}/wp-json`;
+  const dnsHostname = config.dnsHostname || resolveHostname(primaryDomain);
+  const expectedCheckHost = config.checkHost || 'check.saraivavision.com.br';
+
+  return [
+    {
+      id: 'server',
+      defaultParams: { target: primaryDomain },
+      run: async () => {
+        if (!isBrowserEnvironment()) {
+          return {
+            status: 'warning',
+            messageId: 'browserOnly',
+          };
+        }
+
+        const start = now();
+        const url = `${primaryDomain}/`;
+
+        try {
+          await fetchWithTimeout(url, {
+            mode: 'no-cors',
+            cache: 'no-store',
+            timeout: DEFAULT_TIMEOUT,
+          });
+
+          return {
+            status: 'success',
+            latency: buildLatency(start),
+            data: { target: url },
+            messageId: 'opaqueResponse',
+          };
+        } catch (error) {
+          const latency = buildLatency(start);
+          if (error?.name === 'AbortError') {
+            return {
+              status: 'error',
+              messageId: 'timeout',
+              latency,
+            };
+          }
+
+          return {
+            status: 'error',
+            messageId: 'fetchError',
+            messageParams: { message: error?.message || 'unknown error' },
+            latency,
+          };
+        }
+      },
+    },
+    {
+      id: 'services',
+      defaultParams: { target: wordpressRestBase },
+      run: async () => {
+        if (!isBrowserEnvironment()) {
+          return {
+            status: 'warning',
+            messageId: 'browserOnly',
+          };
+        }
+
+        const url = `${wordpressRestBase}/pages?per_page=5&_fields=id,slug`;
+        const start = now();
+
+        try {
+          const response = await fetchWithTimeout(url, {
+            mode: 'cors',
+            cache: 'no-store',
+            headers: { Accept: 'application/json' },
+            timeout: DEFAULT_TIMEOUT,
+          });
+          const latency = buildLatency(start);
+
+          if (response.ok) {
+            const payload = await response.json();
+            const count = Array.isArray(payload) ? payload.length : 0;
+            return {
+              status: 'success',
+              latency,
+              data: { count },
+            };
+          }
+
+          if (response.type === 'opaque') {
+            return {
+              status: 'warning',
+              latency,
+              messageId: 'opaqueResponse',
+              data: { target: url },
+            };
+          }
+
+          return {
+            status: 'error',
+            latency,
+            messageId: 'httpError',
+            messageParams: { status: response.status },
+          };
+        } catch (error) {
+          if (error?.name === 'AbortError') {
+            return {
+              status: 'error',
+              messageId: 'timeout',
+              latency: buildLatency(start),
+            };
+          }
+
+          try {
+            await fetchWithTimeout(url, {
+              mode: 'no-cors',
+              cache: 'no-store',
+              timeout: DEFAULT_TIMEOUT,
+            });
+
+            return {
+              status: 'warning',
+              latency: buildLatency(start),
+              messageId: 'opaqueResponse',
+              data: { target: url },
+            };
+          } catch (secondaryError) {
+            return {
+              status: 'error',
+              messageId: 'fetchError',
+              messageParams: { message: secondaryError?.message || error?.message || 'unknown error' },
+              latency: buildLatency(start),
+            };
+          }
+        }
+      },
+    },
+    {
+      id: 'api',
+      defaultParams: { target: wordpressRestBase },
+      run: async () => {
+        if (!isBrowserEnvironment()) {
+          return {
+            status: 'warning',
+            messageId: 'browserOnly',
+          };
+        }
+
+        const url = `${wordpressRestBase}/posts?per_page=1&_fields=id,date`;
+        const start = now();
+
+        try {
+          const response = await fetchWithTimeout(url, {
+            mode: 'cors',
+            cache: 'no-store',
+            headers: { Accept: 'application/json' },
+            timeout: DEFAULT_TIMEOUT,
+          });
+          const latency = buildLatency(start);
+
+          if (response.ok) {
+            const payload = await response.json();
+            const count = Array.isArray(payload) ? payload.length : 0;
+            return {
+              status: 'success',
+              latency,
+              data: { count },
+            };
+          }
+
+          if (response.type === 'opaque') {
+            return {
+              status: 'warning',
+              latency,
+              messageId: 'opaqueResponse',
+              data: { target: url },
+            };
+          }
+
+          return {
+            status: 'error',
+            latency,
+            messageId: 'httpError',
+            messageParams: { status: response.status },
+          };
+        } catch (error) {
+          if (error?.name === 'AbortError') {
+            return {
+              status: 'error',
+              messageId: 'timeout',
+              latency: buildLatency(start),
+            };
+          }
+
+          try {
+            await fetchWithTimeout(url, {
+              mode: 'no-cors',
+              cache: 'no-store',
+              timeout: DEFAULT_TIMEOUT,
+            });
+
+            return {
+              status: 'warning',
+              latency: buildLatency(start),
+              messageId: 'opaqueResponse',
+              data: { target: url },
+            };
+          } catch (secondaryError) {
+            return {
+              status: 'error',
+              messageId: 'fetchError',
+              messageParams: { message: secondaryError?.message || error?.message || 'unknown error' },
+              latency: buildLatency(start),
+            };
+          }
+        }
+      },
+    },
+    {
+      id: 'routes',
+      defaultParams: { target: wordpressRoot },
+      run: async () => {
+        if (!isBrowserEnvironment()) {
+          return {
+            status: 'warning',
+            messageId: 'browserOnly',
+          };
+        }
+
+        const url = wordpressRoot;
+        const start = now();
+        const importantRoutes = ['/wp/v2/posts', '/wp/v2/pages', '/wp/v2/categories'];
+
+        try {
+          const response = await fetchWithTimeout(url, {
+            mode: 'cors',
+            cache: 'no-store',
+            headers: { Accept: 'application/json' },
+            timeout: DEFAULT_TIMEOUT,
+          });
+          const latency = buildLatency(start);
+
+          if (response.ok) {
+            const payload = await response.json();
+            const routes = payload?.routes ? Object.keys(payload.routes) : [];
+            const missing = importantRoutes.filter((route) => !routes.includes(route));
+            const data = {
+              totalRoutes: routes.length,
+              missingRoutes: missing,
+            };
+
+            if (missing.length === 0) {
+              return {
+                status: 'success',
+                latency,
+                data,
+              };
+            }
+
+            return {
+              status: 'warning',
+              latency,
+              data,
+              messageId: 'missingRoutes',
+              messageParams: { missing: missing.join(', ') },
+            };
+          }
+
+          if (response.type === 'opaque') {
+            return {
+              status: 'warning',
+              latency,
+              messageId: 'opaqueResponse',
+              data: { target: url },
+            };
+          }
+
+          return {
+            status: 'error',
+            latency,
+            messageId: 'httpError',
+            messageParams: { status: response.status },
+          };
+        } catch (error) {
+          if (error?.name === 'AbortError') {
+            return {
+              status: 'error',
+              messageId: 'timeout',
+              latency: buildLatency(start),
+            };
+          }
+
+          try {
+            await fetchWithTimeout(url, {
+              mode: 'no-cors',
+              cache: 'no-store',
+              timeout: DEFAULT_TIMEOUT,
+            });
+
+            return {
+              status: 'warning',
+              latency: buildLatency(start),
+              messageId: 'opaqueResponse',
+              data: { target: url },
+            };
+          } catch (secondaryError) {
+            return {
+              status: 'error',
+              messageId: 'fetchError',
+              messageParams: { message: secondaryError?.message || error?.message || 'unknown error' },
+              latency: buildLatency(start),
+            };
+          }
+        }
+      },
+    },
+    {
+      id: 'dns',
+      defaultParams: { hostname: dnsHostname },
+      run: async () => {
+        const url = `https://dns.google/resolve?name=${encodeURIComponent(dnsHostname)}&type=A`;
+        const start = now();
+
+        try {
+          const response = await fetchWithTimeout(url, {
+            mode: 'cors',
+            cache: 'no-store',
+            timeout: DEFAULT_TIMEOUT,
+          });
+          const latency = buildLatency(start);
+
+          if (!response.ok) {
+            return {
+              status: 'error',
+              latency,
+              messageId: 'httpError',
+              messageParams: { status: response.status },
+            };
+          }
+
+          const payload = await response.json();
+          const records = Array.isArray(payload?.Answer)
+            ? payload.Answer.filter((answer) => typeof answer?.data === 'string').map((answer) => answer.data)
+            : [];
+
+          if (records.length === 0) {
+            return {
+              status: 'warning',
+              latency,
+              data: { records },
+            };
+          }
+
+          return {
+            status: 'success',
+            latency,
+            data: { records },
+          };
+        } catch (error) {
+          if (error?.name === 'AbortError') {
+            return {
+              status: 'error',
+              messageId: 'timeout',
+              latency: buildLatency(start),
+            };
+          }
+
+          return {
+            status: 'error',
+            messageId: 'fetchError',
+            messageParams: { message: error?.message || 'unknown error' },
+            latency: buildLatency(start),
+          };
+        }
+      },
+    },
+    {
+      id: 'ip',
+      defaultParams: { hostname: dnsHostname },
+      run: async () => {
+        const start = now();
+        const queries = [
+          `https://dns.google/resolve?name=${encodeURIComponent(dnsHostname)}&type=A`,
+          `https://dns.google/resolve?name=${encodeURIComponent(dnsHostname)}&type=AAAA`,
+        ];
+
+        try {
+          const [ipv4Response, ipv6Response] = await Promise.all(
+            queries.map((endpoint) =>
+              fetchWithTimeout(endpoint, {
+                mode: 'cors',
+                cache: 'no-store',
+                timeout: DEFAULT_TIMEOUT,
+              })
+            )
+          );
+          const latency = buildLatency(start);
+
+          if (!ipv4Response.ok && !ipv6Response.ok) {
+            return {
+              status: 'error',
+              latency,
+              messageId: 'httpError',
+              messageParams: { status: ipv4Response.status || ipv6Response.status },
+            };
+          }
+
+          const ipv4Payload = ipv4Response.ok ? await ipv4Response.json() : { Answer: [] };
+          const ipv6Payload = ipv6Response.ok ? await ipv6Response.json() : { Answer: [] };
+
+          const ipv4 = Array.isArray(ipv4Payload.Answer)
+            ? ipv4Payload.Answer.filter((answer) => typeof answer?.data === 'string').map((answer) => answer.data)
+            : [];
+          const ipv6 = Array.isArray(ipv6Payload.Answer)
+            ? ipv6Payload.Answer.filter((answer) => typeof answer?.data === 'string').map((answer) => answer.data)
+            : [];
+
+          if (ipv4.length === 0 && ipv6.length === 0) {
+            return {
+              status: 'warning',
+              latency,
+              data: { ipv4, ipv6 },
+            };
+          }
+
+          return {
+            status: 'success',
+            latency,
+            data: { ipv4, ipv6 },
+          };
+        } catch (error) {
+          if (error?.name === 'AbortError') {
+            return {
+              status: 'error',
+              messageId: 'timeout',
+              latency: buildLatency(start),
+            };
+          }
+
+          return {
+            status: 'error',
+            messageId: 'fetchError',
+            messageParams: { message: error?.message || 'unknown error' },
+            latency: buildLatency(start),
+          };
+        }
+      },
+    },
+    {
+      id: 'ssl',
+      defaultParams: { target: primaryDomain },
+      run: async () => {
+        if (!isBrowserEnvironment()) {
+          return {
+            status: 'warning',
+            messageId: 'browserOnly',
+          };
+        }
+
+        const start = now();
+        const url = `${primaryDomain}/`;
+
+        try {
+          await fetchWithTimeout(url, {
+            mode: 'no-cors',
+            cache: 'no-store',
+            timeout: DEFAULT_TIMEOUT,
+          });
+
+          return {
+            status: 'success',
+            latency: buildLatency(start),
+            data: { target: url },
+            messageId: 'opaqueResponse',
+          };
+        } catch (error) {
+          const latency = buildLatency(start);
+          if (error?.name === 'AbortError') {
+            return {
+              status: 'error',
+              messageId: 'timeout',
+              latency,
+            };
+          }
+
+          return {
+            status: 'error',
+            messageId: 'fetchError',
+            messageParams: { message: error?.message || 'unknown error' },
+            latency,
+          };
+        }
+      },
+    },
+    {
+      id: 'subdomain',
+      defaultParams: { expected: expectedCheckHost },
+      run: async () => {
+        if (!isBrowserEnvironment()) {
+          return {
+            status: 'warning',
+            messageId: 'browserOnly',
+          };
+        }
+
+        const host = window.location?.hostname || '';
+        const protocol = window.location?.protocol || '';
+
+        if (!host) {
+          return {
+            status: 'warning',
+            messageId: 'hostnameUnavailable',
+          };
+        }
+
+        if (host !== expectedCheckHost) {
+          return {
+            status: 'warning',
+            data: { hostname: host, protocol },
+            messageId: 'hostMismatch',
+            messageParams: { hostname: host, expected: expectedCheckHost },
+          };
+        }
+
+        if (protocol !== 'https:') {
+          return {
+            status: 'warning',
+            data: { hostname: host, protocol },
+            messageId: 'insecureProtocol',
+            messageParams: { protocol },
+          };
+        }
+
+        return {
+          status: 'success',
+          data: { hostname: host, protocol },
+        };
+      },
+    },
+    {
+      id: 'php',
+      defaultParams: { target: primaryDomain },
+      run: async () => {
+        if (!isBrowserEnvironment()) {
+          return {
+            status: 'warning',
+            messageId: 'browserOnly',
+          };
+        }
+
+        const url = `${primaryDomain}/?rest_route=/`;
+        const start = now();
+
+        try {
+          const response = await fetchWithTimeout(url, {
+            mode: 'cors',
+            cache: 'no-store',
+            headers: { Accept: 'application/json' },
+            timeout: DEFAULT_TIMEOUT,
+          });
+          const latency = buildLatency(start);
+
+          if (response.ok) {
+            const payload = await response.json();
+            const routesCount = payload?.routes ? Object.keys(payload.routes).length : 0;
+            return {
+              status: 'success',
+              latency,
+              data: { namespace: payload?.namespace, routes: routesCount },
+            };
+          }
+
+          if (response.type === 'opaque') {
+            return {
+              status: 'warning',
+              latency,
+              messageId: 'opaqueResponse',
+              data: { target: url },
+            };
+          }
+
+          return {
+            status: 'error',
+            latency,
+            messageId: 'httpError',
+            messageParams: { status: response.status },
+          };
+        } catch (error) {
+          if (error?.name === 'AbortError') {
+            return {
+              status: 'error',
+              messageId: 'timeout',
+              latency: buildLatency(start),
+            };
+          }
+
+          try {
+            await fetchWithTimeout(url, {
+              mode: 'no-cors',
+              cache: 'no-store',
+              timeout: DEFAULT_TIMEOUT,
+            });
+
+            return {
+              status: 'warning',
+              latency: buildLatency(start),
+              messageId: 'opaqueResponse',
+              data: { target: url },
+            };
+          } catch (secondaryError) {
+            return {
+              status: 'error',
+              messageId: 'fetchError',
+              messageParams: { message: secondaryError?.message || error?.message || 'unknown error' },
+              latency: buildLatency(start),
+            };
+          }
+        }
+      },
+    },
+    {
+      id: 'nginx',
+      defaultParams: { target: wordpressRoot },
+      run: async () => {
+        if (!isBrowserEnvironment()) {
+          return {
+            status: 'warning',
+            messageId: 'browserOnly',
+          };
+        }
+
+        const url = wordpressRoot;
+        const start = now();
+
+        try {
+          const response = await fetchWithTimeout(url, {
+            mode: 'cors',
+            cache: 'no-store',
+            headers: { Accept: 'application/json' },
+            timeout: DEFAULT_TIMEOUT,
+          });
+          const latency = buildLatency(start);
+
+          if (!response.ok) {
+            return {
+              status: 'error',
+              latency,
+              messageId: 'httpError',
+              messageParams: { status: response.status },
+            };
+          }
+
+          const serverHeader = response.headers?.get?.('server');
+          if (serverHeader) {
+            return {
+              status: 'success',
+              latency,
+              data: { server: serverHeader },
+            };
+          }
+
+          return {
+            status: 'warning',
+            latency,
+            messageId: 'opaqueResponse',
+            data: { target: url },
+          };
+        } catch (error) {
+          if (error?.name === 'AbortError') {
+            return {
+              status: 'error',
+              messageId: 'timeout',
+              latency: buildLatency(start),
+            };
+          }
+
+          try {
+            await fetchWithTimeout(url, {
+              mode: 'no-cors',
+              cache: 'no-store',
+              timeout: DEFAULT_TIMEOUT,
+            });
+
+            return {
+              status: 'warning',
+              latency: buildLatency(start),
+              messageId: 'opaqueResponse',
+              data: { target: url },
+            };
+          } catch (secondaryError) {
+            return {
+              status: 'error',
+              messageId: 'fetchError',
+              messageParams: { message: secondaryError?.message || error?.message || 'unknown error' },
+              latency: buildLatency(start),
+            };
+          }
+        }
+      },
+    },
+  ];
+}
+
+export default createDiagnostics;


### PR DESCRIPTION
## Summary
- add a new diagnostics page that renders infrastructure health cards and auto-runs checks
- implement reusable diagnostic routines to verify server, DNS, SSL, API, and subdomain bindings
- wire the new page into the router and provide English/Portuguese copy plus SEO metadata

## Testing
- npm test -- --run *(fails: integration suite expects external services and parsing succeeds only with optional binaries installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cb5df8daa083289858cd28b967f477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Diagnostics dashboard to assess server, services, API, routes, DNS, IP, SSL, PHP, NGINX, and subdomain health. Displays statuses, latency, detailed results, last-updated time, and supports reset.
  - Introduced a new /check route and automatic rendering on the “check.” subdomain; unknown paths on that subdomain redirect to the root.
  - Added full English and Portuguese localization for the diagnostics UI, including labels, statuses, SEO metadata, and user messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->