### PR TITLE
Add system checkup automation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ npm run build            # Build para produção
 npm test                 # Testes
 ```
 
+## ✅ Checkup de Sistema
+
+Execute o checkup completo e gere relatórios de saúde:
+
+```bash
+npm run check:system
+```
+
+Instale a rotina automática com cron para monitoramento recorrente:
+
+```bash
+CRON_SCHEDULE="0 */6 * * *" npm run install:checkup-cron
+```
+
+Os relatórios são armazenados em `reports/system-checkup/`.
+
 ## 📦 Tech Stack
 
 - **Frontend**: React 18 + Vite + TypeScript + Tailwind

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "audit:blog-images": "node scripts/validate-blog-compliance-simple.js",
     "fix:image-typos": "bash scripts/fix-image-typos.sh",
     "validate:bundle": "node scripts/validate-client-bundle.js",
-    "production:check": "npm run build && npm run test:run"
+    "production:check": "npm run build && npm run test:run",
+    "check:system": "bash scripts/system-checkup-suite.sh",
+    "install:checkup-cron": "bash scripts/install-system-checkup-cron.sh"
   },
   "dependencies": {
     "@googlemaps/js-api-loader": "^1.16.10",

--- a/scripts/install-system-checkup-cron.sh
+++ b/scripts/install-system-checkup-cron.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+CHECK_SCRIPT="$PROJECT_ROOT/scripts/system-checkup-suite.sh"
+
+if [[ ! -x "$CHECK_SCRIPT" ]]; then
+    echo "Script de checkup não encontrado ou sem permissão de execução: $CHECK_SCRIPT" >&2
+    exit 1
+fi
+
+CRON_SCHEDULE="${CRON_SCHEDULE:-0 */6 * * *}"
+OUTPUT_MODE="${OUTPUT_MODE:-json}"
+LOG_DIR="$PROJECT_ROOT/reports/system-checkup"
+mkdir -p "$LOG_DIR"
+CRON_LOG_FILE="${CRON_LOG_FILE:-$LOG_DIR/cron.log}"
+touch "$CRON_LOG_FILE"
+
+printf -v CHECK_CMD 'cd %q && OUTPUT_MODE=%q %q' "$PROJECT_ROOT" "$OUTPUT_MODE" "$CHECK_SCRIPT"
+printf -v CRON_CMD '%s >> %q 2>&1' "$CHECK_CMD" "$CRON_LOG_FILE"
+
+CURRENT_CRON="$(crontab -l 2>/dev/null || true)"
+TMP_FILE="$(mktemp)"
+trap 'rm -f "$TMP_FILE"' EXIT
+
+if [[ -n "$CURRENT_CRON" ]]; then
+    printf '%s\n' "$CURRENT_CRON" | grep -v "$CHECK_SCRIPT" > "$TMP_FILE" || true
+else
+    : > "$TMP_FILE"
+fi
+
+printf '%s %s\n' "$CRON_SCHEDULE" "$CRON_CMD" >> "$TMP_FILE"
+crontab "$TMP_FILE"
+
+printf 'Cron configurado: %s %s\n' "$CRON_SCHEDULE" "$CRON_CMD"
+printf 'Logs em: %s\n' "$CRON_LOG_FILE"

--- a/scripts/system-checkup-suite.sh
+++ b/scripts/system-checkup-suite.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+OUTPUT_MODE="${OUTPUT_MODE:-text}"
+VERBOSE="${VERBOSE:-false}"
+REPORT_DIR="$PROJECT_ROOT/reports/system-checkup"
+mkdir -p "$REPORT_DIR"
+
+FILE_STAMP="$(date +"%Y%m%d-%H%M%S")"
+ISO_STAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+LOG_FILE="$REPORT_DIR/system-checkup-$FILE_STAMP.log"
+JSON_FILE="$REPORT_DIR/system-checkup-$FILE_STAMP.json"
+touch "$LOG_FILE"
+
+RESULTS_FILE="$(mktemp)"
+trap 'rm -f "$RESULTS_FILE"' EXIT
+
+overall_status="success"
+start_epoch="$(date +%s)"
+
+log_line() {
+    printf '%s\n' "$1" >> "$LOG_FILE"
+    if [[ "$OUTPUT_MODE" != "json" ]]; then
+        printf '%s\n' "$1"
+    fi
+}
+
+run_task() {
+    local key="$1"
+    local label="$2"
+    shift 2
+    local started="$(date +%s)"
+    local output
+    local status
+    if output=$("$@" 2>&1); then
+        status="success"
+    else
+        status="failure"
+    fi
+    local finished="$(date +%s)"
+    local duration=$((finished - started))
+    local encoded_output
+    encoded_output=$(printf '%s' "$output" | base64 | tr -d '\n')
+    printf '%s\t%s\t%s\t%s\t%s\n' "$key" "$label" "$status" "$duration" "$encoded_output" >> "$RESULTS_FILE"
+    printf '===== %s =====\n' "$label" >> "$LOG_FILE"
+    if [[ -n "$output" ]]; then
+        printf '%s\n' "$output" >> "$LOG_FILE"
+    fi
+    if [[ "$status" == "success" ]]; then
+        log_line "[OK] $label (${duration}s)"
+        if [[ "$VERBOSE" == "true" && "$OUTPUT_MODE" != "json" && -n "$output" ]]; then
+            printf '%s\n' "$output"
+        fi
+    else
+        log_line "[FAIL] $label (${duration}s)"
+        if [[ -n "$output" ]]; then
+            printf '%s\n' "$output" >&2
+        fi
+        overall_status="failure"
+    fi
+}
+
+log_line "[INFO] Iniciando checkup em $ISO_STAMP"
+
+run_task "node_version" "Node.js versão" node --version
+run_task "npm_version" "npm versão" npm --version
+run_task "validate_api" "Validação da API" npm run validate:api
+run_task "lint" "Linting" npm run lint
+run_task "test_unit" "Testes unitários" npm run test:unit
+run_task "test_integration" "Testes de integração" npm run test:integration
+run_task "test_api" "Testes de API" npm run test:api
+run_task "test_frontend" "Testes de frontend" npm run test:frontend
+run_task "build" "Build sem prerender" npm run build:norender
+
+end_epoch="$(date +%s)"
+total_duration=$((end_epoch - start_epoch))
+
+node --input-type=module - "$RESULTS_FILE" "$JSON_FILE" "$ISO_STAMP" "$overall_status" "$total_duration" <<'NODE'
+import { readFileSync, writeFileSync } from 'fs'
+const [resultsPath, jsonPath, isoStamp, overallStatus, totalDuration] = process.argv.slice(2)
+const content = readFileSync(resultsPath, 'utf8')
+const rows = content
+  .split('\n')
+  .map(line => line.trim())
+  .filter(Boolean)
+  .map(line => {
+    const [key, label, status, durationSeconds, outputBase64] = line.split('\t')
+    return {
+      key,
+      label,
+      status,
+      durationSeconds: Number.parseInt(durationSeconds, 10),
+      outputBase64
+    }
+  })
+writeFileSync(
+  jsonPath,
+  JSON.stringify(
+    {
+      generatedAt: isoStamp,
+      status: overallStatus,
+      durationSeconds: Number.parseInt(totalDuration, 10),
+      results: rows
+    },
+    null,
+    2
+  ),
+  'utf8'
+)
+NODE
+
+if [[ "$OUTPUT_MODE" == "json" ]]; then
+    cat "$JSON_FILE"
+else
+    log_line "[INFO] Status final: $overall_status"
+    log_line "[INFO] Tempo total: ${total_duration}s"
+    log_line "[INFO] Relatório JSON: $JSON_FILE"
+    log_line "[INFO] Log detalhado: $LOG_FILE"
+fi
+
+if [[ "$overall_status" != "success" ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add a comprehensive system checkup runner that executes validation, linting, test, and build pipelines with consolidated reports
- provide an installer to configure recurring cron executions of the checkup and surface npm shortcuts for both scripts
- document how to run the checkup manually and schedule it via cron in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e29dd9a1b48328b728bc57f48548da